### PR TITLE
Bump SGMLStream version to 0.5 and 0.6

### DIFF
--- a/2021-11.md
+++ b/2021-11.md
@@ -12,7 +12,7 @@ Support will be dropped (whichever comes first):
  - When current functionality can not be maintained portably between 4.72 and nightly
  - On January 1st 2022
 
-All packages will receive a bump to their `dot-y` version. So [sgml-stream](https://github.com/hershel-theodore-layton/sgml-stream) will have `v0.5.0` released when support for older hhvm versions is dropped. `v0.4.x` remains available for those unable to upgrade to `v0.5.x`. New features will NOT be added to `v0.4.x`, but patches / bug fixes / security fixes from the `v0.5.x` series that apply to the `v0.4.x` series will be applied and released. Issues that specifically affect `v0.4.x` can be patched when found. I expect use of `v0.4.x` to decline rapidly, so the chances of issues being found will be low.
+All packages will receive a bump to their `dot-y` version. So [sgml-stream](https://github.com/hershel-theodore-layton/sgml-stream) will have `v0.6.0` released when support for older hhvm versions is dropped. `v0.5.x` remains available for those unable to upgrade to `v0.6.x`. New features will NOT be added to `v0.5.x`, but patches / bug fixes / security fixes from the `v0.6.x` series that apply to the `v0.5.x` series will be applied and released. Issues that specifically affect `v0.5.x` can be patched when found. I expect use of `v0.5.x` to decline rapidly, so the chances of issues being found will be low.
 
 _Why no support for 4.93-4.101? Explicit coeffect syntax is available in 4.93._
 


### PR DESCRIPTION
The v0.5.0 release was an unplanned security release.